### PR TITLE
Replaces deprecated url.parse() with WHATWG API

### DIFF
--- a/1/resources/index.js
+++ b/1/resources/index.js
@@ -42,7 +42,8 @@ function sendFile(res, fullFilePath) {
 }
 
 function httpHandler(req, res) {
-  const { pathname, query } = url.parse(req.url, true);
+  const { pathname, searchParams } = new URL(req.url, `http://${req.headers.host}`);
+  // let breed = searchParams.get('breed');
   const method = req.method.toUpperCase();
   if (method === 'GET') {
     if (pathname.includes(`/${config.staticFilesDir}/`)) {


### PR DESCRIPTION
I dug through the documentation and found that url.parse() is deprecated. Great demo 👍 